### PR TITLE
Sdcardfs

### DIFF
--- a/system_prop.mk
+++ b/system_prop.mk
@@ -90,6 +90,10 @@ PRODUCT_PROPERTY_OVERRIDES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     debug.sensors=1
 
+# Storage
+PRODUCT_PROPERTY_OVERRIDES += \
+    ro.sys.sdcardfs=true
+
 # Time
 PRODUCT_PROPERTY_OVERRIDES += \
     persist.timed.enable=true

--- a/system_prop.mk
+++ b/system_prop.mk
@@ -94,6 +94,10 @@ PRODUCT_PROPERTY_OVERRIDES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.sys.sdcardfs=true
 
+# Tethering
+PRODUCT_PROPERTY_OVERRIDES += \
+    net.tethering.noprovisioning=true
+
 # Time
 PRODUCT_PROPERTY_OVERRIDES += \
     persist.timed.enable=true


### PR DESCRIPTION
With the latest changes to the kccat6-3.10.y kernel branch, we can finally enable sdcardfs.

While I was at it, I added the tethering setting from klte